### PR TITLE
feat: Implement profession recommendation system

### DIFF
--- a/Back/professions.json
+++ b/Back/professions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Ingeniero Mecánico",
+    "description": "Diseña, construye y mantiene máquinas, motores y sistemas mecánicos.",
+    "linked_skills": [{ "test_field": "minedisplacementtotal" }]
+  },
+  {
+    "name": "Ensamblador de Electrónica",
+    "description": "Monta componentes electrónicos en placas de circuito impreso.",
+    "linked_skills": [{ "test_field": "purdeassemble" }]
+  },
+  {
+    "name": "Controlador de Tráfico Aéreo",
+    "description": "Coordina el movimiento de aeronaves para mantener la seguridad y la eficiencia.",
+    "linked_skills": [{ "test_field": "activityjtest" }]
+  },
+  {
+    "name": "Cirujano",
+    "description": "Realiza operaciones quirúrgicas para tratar enfermedades y lesiones.",
+    "linked_skills": [{ "test_field": "purdebothhands" }]
+  },
+  {
+    "name": "Piloto de Carreras",
+    "description": "Conduce vehículos de alta velocidad en competencias.",
+    "linked_skills": [{ "test_field": "reaction2" }]
+  }
+]

--- a/Back/src/controllers/tests.controller.js
+++ b/Back/src/controllers/tests.controller.js
@@ -1,6 +1,8 @@
 // Importa el modelo de Tests para interactuar con la base de datos
 import Tests from "../models/tests.models.js";
 import Company from "../models/company.model.js";
+import Professions from "../models/professions.model.js";
+
 // Función para manejar errores y devolver un objeto de respuesta con el status y mensaje
 const errorHandler = (err) => {
   console.error(err); // Para ver el error en la consola
@@ -8,6 +10,92 @@ const errorHandler = (err) => {
     status: err.status || 500,
     message: err.message || "Internal Server Error",
   };
+};
+
+// Función para normalizar un puntaje en una escala de 0 a 100
+const normalizeScore = (score, min, max, invert = false) => {
+  if (max === min) {
+    return 100; // Si el rango es cero, el desempeño es máximo
+  }
+
+  let normalized = ((score - min) / (max - min)) * 100;
+
+  if (invert) {
+    normalized = 100 - normalized; // Si un menor puntaje es mejor, se invierte el resultado
+  }
+
+  // Asegura que el resultado esté entre 0 y 100
+  return Math.max(0, Math.min(100, normalized));
+};
+
+// Objeto de configuración para cada prueba que se va a analizar
+const testConfigurations = {
+  mineplacementtotal: { min: 1, max: 139, invert: true }, // Menos tiempo es mejor
+  minerotationtotal: { min: 1, max: 113, invert: true }, // Menos tiempo es mejor
+  minedisplacementtotal: { min: 1, max: 106, invert: true }, // Menos tiempo es mejor
+  purdedominanthand: { min: 16, max: 21, invert: false }, // Más es mejor
+  purdenodominanthand: { min: 14, max: 20, invert: false }, // Más es mejor
+  purdebothhands: { min: 13, max: 18, invert: false }, // Más es mejor
+  purdeassemble: { min: 37, max: 52, invert: false }, // Más es mejor
+  activityjtest: { min: 43, max: 64, invert: false }, // Más aciertos es mejor
+  reaction1: { min: 43, max: 64, invert: false }, // Más aciertos es mejor
+  reaction2: { min: 1, max: 301, invert: true }, // Menos tiempo es mejor
+  startime: { min: 1, max: 190, invert: true }, // Menos tiempo es mejor
+  startoucherrors: { min: 1, max: 44, invert: true }, // Menos errores es mejor
+};
+
+// Función para analizar los resultados de un test y recomendar profesiones
+export const analyzeTestResults = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const test = await Tests.findById(id);
+
+    if (!test) {
+      return res.status(404).json({ message: "Test no encontrado" });
+    }
+
+    let maxScore = -1;
+    let bestTestField = null;
+
+    // Itera sobre las configuraciones de las pruebas para encontrar el mejor desempeño
+    for (const field in testConfigurations) {
+      if (test[field] !== undefined) {
+        const config = testConfigurations[field];
+        const score = test[field];
+        const normalized = normalizeScore(
+          score,
+          config.min,
+          config.max,
+          config.invert
+        );
+
+        if (normalized > maxScore) {
+          maxScore = normalized;
+          bestTestField = field;
+        }
+      }
+    }
+
+    if (!bestTestField) {
+      return res
+        .status(400)
+        .json({ message: "No se pudo determinar la mejor habilidad del test" });
+    }
+
+    // Busca profesiones que coincidan con el campo de la mejor habilidad
+    const recommendedProfessions = await Professions.find({
+      "linked_skills.test_field": bestTestField,
+    });
+
+    res.status(200).json({
+      bestTestField,
+      normalizedScore: maxScore,
+      recommendedProfessions,
+    });
+  } catch (error) {
+    console.error("Error al analizar los resultados del test:", error);
+    res.status(500).json({ message: "Error interno del servidor" });
+  }
 };
 
 // Función para obtener todos los tests según la consulta proporcionada

--- a/Back/src/libs/seed.js
+++ b/Back/src/libs/seed.js
@@ -1,0 +1,33 @@
+import mongoose from "mongoose";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import Professions from "../models/professions.model.js";
+import { connectDB } from "../db.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const seedProfessions = async () => {
+  try {
+    await connectDB();
+
+    const professionsFilePath = path.join(__dirname, "../../professions.json");
+    const professionsData = JSON.parse(fs.readFileSync(professionsFilePath, "utf-8"));
+
+    await Professions.deleteMany({});
+    console.log("Colección de profesiones limpiada.");
+
+    await Professions.insertMany(professionsData);
+    console.log("Nuevas profesiones insertadas.");
+
+    console.log("¡Seed completado con éxito!");
+  } catch (error) {
+    console.error("Error durante el seeding:", error);
+  } finally {
+    mongoose.disconnect();
+    console.log("Desconectado de la base de datos.");
+  }
+};
+
+seedProfessions();

--- a/Back/src/models/professions.model.js
+++ b/Back/src/models/professions.model.js
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+
+const professionsSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  description: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  linked_skills: [
+    {
+      test_field: {
+        type: String,
+        required: true,
+      },
+    },
+  ],
+});
+
+export default mongoose.model("Professions", professionsSchema);

--- a/Back/src/models/tests.models.js
+++ b/Back/src/models/tests.models.js
@@ -37,48 +37,48 @@ const testsSchema = new mongoose.Schema(
     },
     // Tiempos y escalas de pruebas de colocación, rotación y desplazamiento de minas
     mineplacementtime1: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     mineplacementtime2: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     mineplacementtotal: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     mineplacementscale: {
       type: String,
       default: "",
     },
     minerotationtime1: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minerotationtime2: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minerotationtotal: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minerotationscale: {
       type: String,
       default: "",
     },
     minedisplacementtime1: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minedisplacementtime2: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minedisplacementtotal: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     minedisplacementscale: {
       type: String,
@@ -90,32 +90,32 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de purde (mano dominante, no dominante, ambas, ensamblaje)
     purdedominanthand: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     purdedominanthandscale: {
       type: String,
       default: "",
     },
     purdenodominanthand: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     purdenodominanthandscale: {
       type: String,
       default: "",
     },
     purdebothhands: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     purdebothhandsscale: {
       type: String,
       default: "",
     },
     purdeassemble: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     purdeassemblescale: {
       type: String,
@@ -127,8 +127,8 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de actividad J
     activityjtest: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     activityjtestscale: {
       type: String,
@@ -140,16 +140,16 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de reacción
     reaction1: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     reaction1scale: {
       type: String,
       default: "",
     },
     reaction2: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     reaction2scale: {
       type: String,
@@ -161,8 +161,8 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de dedos
     fingers: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     fingersscale: {
       type: String,
@@ -174,20 +174,20 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de visión de colores (Ishihara)
     ishinormalvision: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     ishideuteranopia: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     ishiportanopia: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     ishidaltonism: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     ishiobservations: {
       type: String,
@@ -195,16 +195,16 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de estrella
     startime: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     starTimeOne: {
       type: String,
       default: "",
     },
     startoucherrors: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     starTouchErrorsOne: {
       type: String,
@@ -212,12 +212,12 @@ const testsSchema = new mongoose.Schema(
     },
     // Pruebas de juego de alambre
     wireGameTime: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     wireGameError: {
-      type: String,
-      default: "",
+      type: Number,
+      default: 0,
     },
     wireGameLevel: {
       type: String,

--- a/Back/src/routes/tests.routes.js
+++ b/Back/src/routes/tests.routes.js
@@ -6,6 +6,7 @@ import {
   getTest,
   deleteTest,
   updateTest,
+  analyzeTestResults,
 } from "../controllers/tests.controller.js";
 import { authRequierd } from "../middlewares/validateToken.js"; // 👈 importa tu middleware
 
@@ -14,6 +15,9 @@ const router = Router();
 
 // Obtiene todos los tests
 router.get("/tests", authRequierd, getTests);
+
+// Ruta para analizar los resultados de un test específico
+router.get("/tests/:id/analyze", authRequierd, analyzeTestResults);
 
 // Obtiene un test específico por ID
 router.get("/tests/:id", authRequierd, getTest);

--- a/Front/src/api/test.js
+++ b/Front/src/api/test.js
@@ -9,3 +9,5 @@ export const createTestsRequest = (tests) => axios.post("/tests", tests);
 export const updateTestsRequest = (tests) => axios.put(`/tests/${tests._id}`, tests);
 
 export const deleteTestsRequest =  (id) => axios.delete(`/tests/${id}`);
+
+export const analyzeTestRequest = (id) => axios.get(`/tests/${id}/analyze`);

--- a/Front/src/components/ProfessionRecommendation.jsx
+++ b/Front/src/components/ProfessionRecommendation.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from "react";
+import { analyzeTestRequest } from "../api/test.js";
+import PropTypes from "prop-types";
+
+function ProfessionRecommendation({ testId }) {
+  const [recommendations, setRecommendations] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchRecommendations = async () => {
+      try {
+        const res = await analyzeTestRequest(testId);
+        setRecommendations(res.data);
+      } catch (err) {
+        setError("No se pudieron cargar las recomendaciones.");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecommendations();
+  }, [testId]);
+
+  if (loading) {
+    return <p className="text-white">Cargando recomendaciones...</p>;
+  }
+
+  if (error) {
+    return <p className="text-red-500">{error}</p>;
+  }
+
+  if (!recommendations || recommendations.recommendedProfessions.length === 0) {
+    return (
+      <p className="text-white">
+        No se encontraron profesiones recomendadas para este test.
+      </p>
+    );
+  }
+
+  return (
+    <div className="bg-gray-800 p-6 rounded-md mt-4">
+      <h3 className="text-xl font-bold text-white mb-4">
+        Profesiones Recomendadas
+      </h3>
+      <p className="text-gray-300 mb-2">
+        Habilidad más destacada:{" "}
+        <span className="font-semibold">{recommendations.bestTestField}</span>{" "}
+        con un puntaje normalizado de{" "}
+        <span className="font-semibold">
+          {recommendations.normalizedScore.toFixed(2)}%
+        </span>
+        .
+      </p>
+      <ul className="space-y-4">
+        {recommendations.recommendedProfessions.map((profession) => (
+          <li key={profession._id} className="bg-gray-700 p-4 rounded-md">
+            <h4 className="text-lg font-bold text-white">{profession.name}</h4>
+            <p className="text-gray-300">{profession.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ProfessionRecommendation.propTypes = {
+  testId: PropTypes.string.isRequired,
+};
+
+export default ProfessionRecommendation;

--- a/Front/src/components/TestsIndex.jsx
+++ b/Front/src/components/TestsIndex.jsx
@@ -1,12 +1,14 @@
-import { format } from "date-fns";
+import { useState } from "react";
 import { useTests } from "../context/TestsContext";
 import { useAuth } from "../context/AuthContext"; // 👈 aquí traemos el rol
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import ProfessionRecommendation from "./ProfessionRecommendation";
 
 function TestsIndex({ tests }) {
   const { deleteTests } = useTests();
   const { isAdmin, isConsultant, isEmployee } = useAuth(); // 👈 helpers que revisan rol
+  const [showRecommendations, setShowRecommendations] = useState(false);
 
   return (
     <div className="bg-blueSena max-w-full w-full p-6 rounded-md overflow-auto mb-6">
@@ -227,6 +229,14 @@ function TestsIndex({ tests }) {
           </tbody>
         </table>
         <div className="flex justify-end mt-4 gap-2">
+          <button
+            onClick={() => setShowRecommendations(!showRecommendations)}
+            className="bg-green-500 text-white px-4 py-2 rounded-md"
+          >
+            {showRecommendations
+              ? "Ocultar Recomendaciones"
+              : "Ver Recomendaciones"}
+          </button>
           {/* 🔴 Solo Admin ve todos */}
           {isAdmin() && (
             <>
@@ -286,6 +296,7 @@ function TestsIndex({ tests }) {
           )}
         </div>
       </header>
+      {showRecommendations && <ProfessionRecommendation testId={tests._id} />}
     </div>
   );
 }
@@ -302,52 +313,52 @@ TestsIndex.propTypes = {
       headquarters: PropTypes.string,
     }),
     dominanthand: PropTypes.string,
-    mineplacementtime1: PropTypes.string,
-    mineplacementtime2: PropTypes.string,
-    mineplacementtotal: PropTypes.string,
+    mineplacementtime1: PropTypes.number,
+    mineplacementtime2: PropTypes.number,
+    mineplacementtotal: PropTypes.number,
     mineplacementscale: PropTypes.string,
-    minerotationtime1: PropTypes.string,
-    minerotationtime2: PropTypes.string,
-    minerotationtotal: PropTypes.string,
+    minerotationtime1: PropTypes.number,
+    minerotationtime2: PropTypes.number,
+    minerotationtotal: PropTypes.number,
     minerotationscale: PropTypes.string,
-    minedisplacementtime1: PropTypes.string,
-    minedisplacementtime2: PropTypes.string,
-    minedisplacementtotal: PropTypes.string,
+    minedisplacementtime1: PropTypes.number,
+    minedisplacementtime2: PropTypes.number,
+    minedisplacementtotal: PropTypes.number,
     minedisplacementscale: PropTypes.string,
     mineobservations: PropTypes.string,
-    purdedominanthand: PropTypes.string,
+    purdedominanthand: PropTypes.number,
     purdedominanthandscale: PropTypes.string,
-    purdenodominanthand: PropTypes.string,
+    purdenodominanthand: PropTypes.number,
     purdenodominanthandscale: PropTypes.string,
-    purdebothhands: PropTypes.string,
+    purdebothhands: PropTypes.number,
     purdebothhandsscale: PropTypes.string,
-    purdeassemble: PropTypes.string,
+    purdeassemble: PropTypes.number,
     purdeassemblescale: PropTypes.string,
     purdeobservations: PropTypes.string,
-    activityjtest: PropTypes.string,
+    activityjtest: PropTypes.number,
     activityjtestscale: PropTypes.string,
     activityjtestobservations: PropTypes.string,
-    reaction1: PropTypes.string,
+    reaction1: PropTypes.number,
     reaction1scale: PropTypes.string,
-    reaction2: PropTypes.string,
+    reaction2: PropTypes.number,
     reaction2scale: PropTypes.string,
     reactionobservations: PropTypes.string,
-    startime: PropTypes.string,
+    startime: PropTypes.number,
     starTimeOne: PropTypes.string,
-    startoucherrors: PropTypes.string,
+    startoucherrors: PropTypes.number,
     starTouchErrorsOne: PropTypes.string,
-    wireGameTime: PropTypes.string,
-    wireGameError: PropTypes.string,
+    wireGameTime: PropTypes.number,
+    wireGameError: PropTypes.number,
     wireGameLevel: PropTypes.string,
     visualAcuity: PropTypes.string,
     visualAcuityLevel: PropTypes.string,
-    fingers: PropTypes.string,
+    fingers: PropTypes.number,
     fingersscale: PropTypes.string,
     fingersobservations: PropTypes.string,
-    ishinormalvision: PropTypes.string,
-    ishideuteranopia: PropTypes.string,
-    ishiportanopia: PropTypes.string,
-    ishidaltonism: PropTypes.string,
+    ishinormalvision: PropTypes.number,
+    ishideuteranopia: PropTypes.number,
+    ishiportanopia: PropTypes.number,
+    ishidaltonism: PropTypes.number,
     ishiobservations: PropTypes.string,
   }).isRequired,
 };


### PR DESCRIPTION
This commit introduces a full-stack profession recommendation system based on psychotechnical test results.

Backend:
- Adds a new `Professions` model and a seeder script to populate the database.
- Modifies the `Tests` model to use `Number` for score fields, enabling calculations.
- Implements an analysis controller with `normalizeScore` and `analyzeTestResults` functions.
- The `normalizeScore` function handles both direct and inverse scoring.
- The `analyzeTestResults` function identifies the user's best skill and finds linked professions.
- Adds a new API endpoint `GET /tests/:id/analyze` to expose this functionality.

Frontend:
- Creates a `ProfessionRecommendation` component to display the results.
- Adds a button to the `TestsIndex` component to show/hide recommendations.
- Updates the API client to call the new analysis endpoint.